### PR TITLE
Added option to re-sort the editor tabs to match the tab switcher list

### DIFF
--- a/lib/tab-list.coffee
+++ b/lib/tab-list.coffee
@@ -37,6 +37,8 @@ class TabList
 
     @disposable.add @pane.observeActiveItem (item) =>
       @_moveItemToFront(item)
+      if atom.config.get 'tab-switcher.reSortTabs'
+        @pane.moveItem(item, 0)
 
   updateAnimationDelay: (delay) ->
     @view.updateAnimationDelay(delay)

--- a/lib/tab-switcher.coffee
+++ b/lib/tab-switcher.coffee
@@ -45,6 +45,11 @@ module.exports =
       default: 0.1,
       title: 'Pause before displaying tab switcher, in seconds'
       description: 'Increasing this can reduce flicker when switching quickly.'
+    reSortTabs:
+      type: 'boolean'
+      default: false
+      title: 'Sort editor tabs'
+      description: "Move the editor tabs to match the tab-switcher list"
 
   activate: (state) ->
     @disposable = new CompositeDisposable


### PR DESCRIPTION
It looks a little unnatural when you select the tab with the mouse though. Maybe I can add an animation or a delay somehow so it looks more fluid.