### PR TITLE
Give focus to the editor pane when the switch is canceled

### DIFF
--- a/lib/tab-list.coffee
+++ b/lib/tab-list.coffee
@@ -164,4 +164,5 @@ class TabList
       unless @currentIndex is null
         @currentIndex = null
         @view.currentTabChanged(null)
+    @pane.activate()
     @view.hide()


### PR DESCRIPTION
When we triggered the "cancel" action no pane had focus.